### PR TITLE
Add a configurable server port numner to the Nuxt config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,6 +19,10 @@ export default {
     '~/assets/global.scss'
   ],
 
+  server: {
+    port: 3008 // default: 3000
+  },
+
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [],
 


### PR DESCRIPTION
#### **Description**

* Set the default server port to **3008**, to avoid conflicts with other local servers already running on **3000**.